### PR TITLE
Add window centering.

### DIFF
--- a/rendy/examples/meshes/main.rs
+++ b/rendy/examples/meshes/main.rs
@@ -373,6 +373,8 @@ fn main() {
     let surface = factory.create_surface(window.into());
     let aspect = surface.aspect();
 
+    surface.center();
+
     let mut graph_builder = GraphBuilder::<Backend, Aux<Backend>>::new();
 
     let color = graph_builder.create_image(

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -353,6 +353,7 @@ fn main() {
     event_loop.poll_events(|_| ());
 
     let surface = factory.create_surface(window.into());
+    surface.center();
 
     let mut graph_builder = GraphBuilder::<Backend, ()>::new();
 

--- a/rendy/examples/triangle/main.rs
+++ b/rendy/examples/triangle/main.rs
@@ -254,6 +254,12 @@ fn main() {
 
     let surface = factory.create_surface(window.into());
 
+    // Call set_center_monitor(1) to center the monitor on monitor 1,
+    // this only works if you have mutliple monitors.
+
+    // This centers the monitor on the screen.
+    surface.center();
+
     let mut graph_builder = GraphBuilder::<Backend, ()>::new();
 
     let color = graph_builder.create_image(

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -223,6 +223,44 @@ where
     pub fn window(&self) -> &winit::Window {
         &self.window
     }
+
+    /// Centers the window on the current monitor the window lives in.
+    pub fn center(&self) {
+        self.set_centered(self.window.get_current_monitor())
+    }
+
+    /// Centers the window on the specified target monitor, falls back to primary monitor if out range.
+    pub fn set_center_monitor(&self, monitor_target: usize) {
+        if monitor_target < self.window.get_available_monitors().count() {
+            self.set_centered(
+                self.window
+                    .get_available_monitors()
+                    .nth(monitor_target)
+                    .unwrap(),
+            )
+        } else {
+            self.set_centered(self.window.get_primary_monitor());
+        }
+    }
+
+    /// Sets the window position to be in the center of the given monitor.
+    pub fn set_centered(&self, monitor: winit::MonitorId) {
+        let window_size = match self.window.get_outer_size() {
+            Some(logical_size) => logical_size,
+            None => return,
+        };
+
+        let monitor_size = monitor.get_dimensions();
+        let monitor_position = monitor.get_position();
+
+        let mut monitor_window_position: winit::dpi::LogicalPosition = (0.0, 0.0).into();
+        monitor_window_position.x =
+            monitor_position.x + (monitor_size.width * 0.5) - (&window_size.width * 0.5);
+        monitor_window_position.y =
+            monitor_position.y + (monitor_size.height * 0.5) - (&window_size.height * 0.5);
+
+        &self.window.set_position(monitor_window_position);
+    }
 }
 
 unsafe fn create_swapchain<B: Backend>(


### PR DESCRIPTION
Added centering functions in the surface, this should work on all platforms that support window placement.

* surface.set_centered();
* surface.set_center_monitor(usize);  - This centers the monitor on the given monitor if it exists
* surface.set_centered(winit::MonitorId)

This can be reverted if Winit accepts my PR.
then it's just surface.window.set_centered();